### PR TITLE
fix: fix Linux and macOS build scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- [#20](https://github.com/pytauri/create-pytauri-app/pull/20) - fix: fix Linux and macOS build scripts.
+
+    - Pass the `libpython` path correctly on Linux and macOS as `-L` arguments to `RUSTFLAGS`.
+    - Temporarily disable `appimage` bundle target
+
+        Currently unable to build `appimage`, see <https://github.com/python-pillow/Pillow/issues/9198>.
+
+    - Change the default `identifier` to `com.username.{{ project_name }}`
+
+        Tauri no longer recommends identifiers ending with `.app`, see <https://github.com/tauri-apps/tauri/issues/12674>.
+
 ### Security
 
 - [#19](https://github.com/pytauri/create-pytauri-app/pull/19) - chore(deps-dev): bump vite from 6.3.5 to 6.3.6 in the npm_and_yarn group across 1 directory.

--- a/copier.yaml
+++ b/copier.yaml
@@ -13,7 +13,7 @@ package_name:
 identifier:
     type: str
     help: Identifier
-    default: "com.{{ project_name }}.app"
+    default: "com.username.{{ project_name }}"
 
 template:
     type: str

--- a/templates/{{ '.' }}/{{ project_name }}/scripts/linux/build.sh.jinja
+++ b/templates/{{ '.' }}/{{ project_name }}/scripts/linux/build.sh.jinja
@@ -5,12 +5,13 @@ set -e
 cd "$(dirname "$0")/../.."
 
 PROJECT_NAME="{{ project_name }}"
+PYLIB_DIR="$(realpath src-tauri/pyembed/python/lib)"
 
 export PYTAURI_STANDALONE="1"
 export PYO3_PYTHON="$(realpath src-tauri/pyembed/python/bin/python3)"
 export RUSTFLAGS=" \
     -C link-arg=-Wl,-rpath,\$ORIGIN/../lib/$PROJECT_NAME/lib \
-    -L \"$PYO3_PYTHON\""
+    -L $PYLIB_DIR"
 
 uv pip install \
     --exact \

--- a/templates/{{ '.' }}/{{ project_name }}/scripts/macos/build.sh.jinja
+++ b/templates/{{ '.' }}/{{ project_name }}/scripts/macos/build.sh.jinja
@@ -11,7 +11,7 @@ export PYTAURI_STANDALONE="1"
 export PYO3_PYTHON="$(realpath src-tauri/pyembed/python/bin/python3)"
 export RUSTFLAGS=" \
     -C link-arg=-Wl,-rpath,@executable_path/../Resources/lib \
-    -L \"$PYLIB_DIR\""
+    -L $PYLIB_DIR"
 
 uv pip install \
     --exact \

--- a/templates/{{ '.' }}/{{ project_name }}/src-tauri/tauri.bundle.json
+++ b/templates/{{ '.' }}/{{ project_name }}/src-tauri/tauri.bundle.json
@@ -1,7 +1,14 @@
 {
   "bundle": {
     "active": true,
-    "targets": "all",
+    "targets": [
+      "deb",
+      "rpm",
+      "msi",
+      "nsis",
+      "app",
+      "dmg"
+    ],
     "resources": {
       "pyembed/python": "./"
     }

--- a/templates/{{ '.' }}/{{ project_name }}/src-tauri/tauri.conf.json.jinja
+++ b/templates/{{ '.' }}/{{ project_name }}/src-tauri/tauri.conf.json.jinja
@@ -23,8 +23,7 @@
     }
   },
   "bundle": {
-    "active": true,
-    "targets": "all",
+    "active": false,
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",


### PR DESCRIPTION
Issues found in pytauri/example-nicegui-app#3:

- Pass the `libpython` path correctly on Linux and macOS as `-L` arguments to `RUSTFLAGS`.

    - In b2404462275b9c9f1aacb2fd74ccf4d9de50a243 I don't know why (most likely I forgot) the `-L` argument was not set for `linux/build.sh`.
    - The `-L` argument in `macos/build.sh` is also incorrect; the quotes cause `-L "\"usr\lib\""`.

- Temporarily disable the `appimage` bundle target

    Currently unable to build `appimage`, see <https://github.com/python-pillow/Pillow/issues/9198>.

- Change the default `identifier` to `com.username.{{ project_name }}`

    Tauri no longer recommends identifiers ending with `.app`, see <https://github.com/tauri-apps/tauri/issues/12674>.

    In <https://github.com/tauri-apps/create-tauri-app/pull/900> they changed it to `com.{whoami}.{project_name}`.
    I spent some time investigating and found that unless we enable the `--unsafe` feature to add a custom Jinja extension, we cannot obtain the username.
    So I decided to change it to `com.username.{{ project_name }}` for now.
