### PR TITLE
fix(svelte): fix incorrect `frontendDist` path in svelte template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- [#22](https://github.com/pytauri/create-pytauri-app/pull/22) - fix(svelte): fix incorrect `frontendDist` path in svelte template.
+
+    The output directory for Svelte template has now been changed from `build` directory to `dist` directory to match the `build.frontendDist` setting in `tauri.conf.json`.
+
 - [#20](https://github.com/pytauri/create-pytauri-app/pull/20) - fix: fix Linux and macOS build scripts.
 
     - Pass the `libpython` path correctly on Linux and macOS as `-L` arguments to `RUSTFLAGS`.

--- a/templates/{% if template == 'svelte' %}.{% endif %}/{{ project_name }}/svelte.config.js
+++ b/templates/{% if template == 'svelte' %}.{% endif %}/{{ project_name }}/svelte.config.js
@@ -10,6 +10,8 @@ const config = {
   preprocess: vitePreprocess(),
   kit: {
     adapter: adapter({
+      // match `build.frontendDist` in `tauri.conf.json`
+      pages: "dist",
       fallback: "index.html",
     }),
   },


### PR DESCRIPTION
This was discovered in #21: <https://github.com/pytauri/create-pytauri-app/actions/runs/17697765693/job/50299377278?pr=21#step:15:119>

Unlike Vue and React, Svelte doesn't follow Vite's `build.outDir` configuration. Its output directory is specified by [`adapter-static`](https://stackoverflow.com/a/77242777), which defaults to `build` instead of `dist`. This caused build failures because `build.frontendDist` in `tauri.conf.json` was set to `../dist`.

In fact, create-tauri-app does [specifically set `../build` as `frontendDist` for Svelte](https://github.com/tauri-apps/create-tauri-app/blob/8d15234e7b473afe68c8601e88f11d1646157404/templates/template-svelte/.manifest#L8). However, for the existing architecture of create-pytauri-app, I don't want to create a special case for `svelte` in `templates/./{{ project_name }}`. So I chose to change the output directory in `svelte.config.js` to `dist`.

CC @ISOR3X, since you are the author of the Svelte template.